### PR TITLE
001: tsk — CLI task tracker

### DIFF
--- a/cmd/tsk/main.go
+++ b/cmd/tsk/main.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/zarldev/claude-mngr/internal/task"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(1)
+	}
+
+	path, err := task.DefaultPath()
+	if err != nil {
+		fatal(err)
+	}
+	s := task.NewStore(path)
+
+	switch os.Args[1] {
+	case "add":
+		runAdd(s, os.Args[2:])
+	case "list":
+		runList(s, os.Args[2:])
+	case "done":
+		runDone(s, os.Args[2:])
+	case "rm":
+		runRm(s, os.Args[2:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
+		usage()
+		os.Exit(1)
+	}
+}
+
+func runAdd(s *task.Store, args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: tsk add <title>")
+		os.Exit(1)
+	}
+	title := strings.Join(args, " ")
+	t, err := s.Add(title)
+	if err != nil {
+		fatal(err)
+	}
+	fmt.Printf("added task %d: %s\n", t.ID, t.Title)
+}
+
+func runList(s *task.Store, args []string) {
+	var filter *bool
+	for _, a := range args {
+		switch a {
+		case "--done":
+			v := true
+			filter = &v
+		case "--pending":
+			v := false
+			filter = &v
+		default:
+			fmt.Fprintf(os.Stderr, "unknown flag: %s\n", a)
+			os.Exit(1)
+		}
+	}
+
+	tasks, err := s.List(filter)
+	if err != nil {
+		fatal(err)
+	}
+	if len(tasks) == 0 {
+		fmt.Println("no tasks")
+		return
+	}
+	for _, t := range tasks {
+		check := "[ ]"
+		if t.Done {
+			check = "[x]"
+		}
+		fmt.Printf("%3d  %s  %-40s  %s\n", t.ID, check, t.Title, age(t.CreatedAt))
+	}
+}
+
+func runDone(s *task.Store, args []string) {
+	if len(args) != 1 {
+		fmt.Fprintln(os.Stderr, "usage: tsk done <id>")
+		os.Exit(1)
+	}
+	id, err := strconv.Atoi(args[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid id: %s\n", args[0])
+		os.Exit(1)
+	}
+	if err := s.Done(id); err != nil {
+		fatal(err)
+	}
+	fmt.Printf("task %d marked done\n", id)
+}
+
+func runRm(s *task.Store, args []string) {
+	if len(args) != 1 {
+		fmt.Fprintln(os.Stderr, "usage: tsk rm <id>")
+		os.Exit(1)
+	}
+	id, err := strconv.Atoi(args[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid id: %s\n", args[0])
+		os.Exit(1)
+	}
+	if err := s.Remove(id); err != nil {
+		fatal(err)
+	}
+	fmt.Printf("task %d removed\n", id)
+}
+
+func usage() {
+	fmt.Fprintln(os.Stderr, `usage: tsk <command> [args]
+
+commands:
+  add <title>       create a new task
+  list [--done|--pending]  show tasks
+  done <id>         mark a task as done
+  rm <id>           remove a task`)
+}
+
+func age(t time.Time) string {
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	}
+}
+
+func fatal(err error) {
+	fmt.Fprintf(os.Stderr, "tsk: %v\n", err)
+	os.Exit(1)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/zarldev/claude-mngr
+
+go 1.23

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -1,0 +1,138 @@
+package task
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// fileData is the on-disk JSON format.
+type fileData struct {
+	NextID int    `json:"next_id"`
+	Tasks  []Task `json:"tasks"`
+}
+
+// Store manages tasks in a JSON file.
+type Store struct {
+	path string
+}
+
+// NewStore creates a store backed by the given file path.
+func NewStore(path string) *Store {
+	return &Store{path: path}
+}
+
+// DefaultPath returns ~/.tasks.json.
+func DefaultPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("home dir: %w", err)
+	}
+	return filepath.Join(home, ".tasks.json"), nil
+}
+
+// load reads all data from the file. Returns zero value if file doesn't exist.
+func (s *Store) load() (fileData, error) {
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fileData{NextID: 1}, nil
+		}
+		return fileData{}, fmt.Errorf("read %s: %w", s.path, err)
+	}
+	if len(data) == 0 {
+		return fileData{NextID: 1}, nil
+	}
+	var fd fileData
+	if err := json.Unmarshal(data, &fd); err != nil {
+		return fileData{}, fmt.Errorf("unmarshal tasks: %w", err)
+	}
+	if fd.NextID == 0 {
+		fd.NextID = 1
+	}
+	return fd, nil
+}
+
+// save writes all data to the file.
+func (s *Store) save(fd fileData) error {
+	data, err := json.MarshalIndent(fd, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal tasks: %w", err)
+	}
+	if err := os.WriteFile(s.path, data, 0644); err != nil {
+		return fmt.Errorf("write %s: %w", s.path, err)
+	}
+	return nil
+}
+
+// Add creates a new task with the given title.
+func (s *Store) Add(title string) (Task, error) {
+	fd, err := s.load()
+	if err != nil {
+		return Task{}, err
+	}
+	t := Task{
+		ID:        fd.NextID,
+		Title:     title,
+		Done:      false,
+		CreatedAt: time.Now(),
+	}
+	fd.NextID++
+	fd.Tasks = append(fd.Tasks, t)
+	if err := s.save(fd); err != nil {
+		return Task{}, err
+	}
+	return t, nil
+}
+
+// List returns all tasks, optionally filtered.
+// filter: nil = all, ptr to true = done only, ptr to false = pending only.
+func (s *Store) List(filter *bool) ([]Task, error) {
+	fd, err := s.load()
+	if err != nil {
+		return nil, err
+	}
+	if filter == nil {
+		return fd.Tasks, nil
+	}
+	var out []Task
+	for _, t := range fd.Tasks {
+		if t.Done == *filter {
+			out = append(out, t)
+		}
+	}
+	return out, nil
+}
+
+// Done marks a task as done by ID.
+func (s *Store) Done(id int) error {
+	fd, err := s.load()
+	if err != nil {
+		return err
+	}
+	for i := range fd.Tasks {
+		if fd.Tasks[i].ID == id {
+			fd.Tasks[i].Done = true
+			return s.save(fd)
+		}
+	}
+	return fmt.Errorf("task %d not found", id)
+}
+
+// Remove deletes a task by ID.
+func (s *Store) Remove(id int) error {
+	fd, err := s.load()
+	if err != nil {
+		return err
+	}
+	for i, t := range fd.Tasks {
+		if t.ID == id {
+			fd.Tasks = append(fd.Tasks[:i], fd.Tasks[i+1:]...)
+			return s.save(fd)
+		}
+	}
+	return fmt.Errorf("task %d not found", id)
+}

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -1,0 +1,188 @@
+package task
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func tempStore(t *testing.T) *Store {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "tasks.json")
+	return NewStore(p)
+}
+
+func TestAdd(t *testing.T) {
+	s := tempStore(t)
+
+	tests := []struct {
+		title  string
+		wantID int
+	}{
+		{"buy milk", 1},
+		{"walk dog", 2},
+		{"read book", 3},
+	}
+	for _, tt := range tests {
+		task, err := s.Add(tt.title)
+		if err != nil {
+			t.Fatalf("add %q: %v", tt.title, err)
+		}
+		if task.ID != tt.wantID {
+			t.Errorf("add %q: got ID %d, want %d", tt.title, task.ID, tt.wantID)
+		}
+		if task.Title != tt.title {
+			t.Errorf("got title %q, want %q", task.Title, tt.title)
+		}
+		if task.Done {
+			t.Errorf("new task should not be done")
+		}
+		if task.CreatedAt.IsZero() {
+			t.Errorf("CreatedAt should be set")
+		}
+	}
+}
+
+func TestList(t *testing.T) {
+	s := tempStore(t)
+
+	// empty store
+	tasks, err := s.List(nil)
+	if err != nil {
+		t.Fatalf("list empty: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("expected 0 tasks, got %d", len(tasks))
+	}
+
+	s.Add("one")
+	s.Add("two")
+	s.Done(1)
+
+	boolPtr := func(v bool) *bool { return &v }
+
+	tests := []struct {
+		name   string
+		filter *bool
+		want   int
+	}{
+		{"all", nil, 2},
+		{"done", boolPtr(true), 1},
+		{"pending", boolPtr(false), 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := s.List(tt.filter)
+			if err != nil {
+				t.Fatalf("list: %v", err)
+			}
+			if len(got) != tt.want {
+				t.Errorf("got %d tasks, want %d", len(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestDone(t *testing.T) {
+	s := tempStore(t)
+	s.Add("task one")
+
+	if err := s.Done(1); err != nil {
+		t.Fatalf("done: %v", err)
+	}
+
+	tasks, _ := s.List(nil)
+	if !tasks[0].Done {
+		t.Error("task should be marked done")
+	}
+
+	// not found
+	if err := s.Done(99); err == nil {
+		t.Error("expected error for missing task")
+	}
+}
+
+func TestRemove(t *testing.T) {
+	s := tempStore(t)
+	s.Add("task one")
+	s.Add("task two")
+
+	if err := s.Remove(1); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	tasks, _ := s.List(nil)
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	if tasks[0].ID != 2 {
+		t.Errorf("remaining task ID should be 2, got %d", tasks[0].ID)
+	}
+
+	// not found
+	if err := s.Remove(99); err == nil {
+		t.Error("expected error for missing task")
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "tasks.json")
+
+	// write with one store instance
+	s1 := NewStore(p)
+	s1.Add("persisted task")
+	s1.Add("another task")
+	s1.Done(2)
+
+	// read with a fresh store instance
+	s2 := NewStore(p)
+	tasks, err := s2.List(nil)
+	if err != nil {
+		t.Fatalf("load from new store: %v", err)
+	}
+	if len(tasks) != 2 {
+		t.Fatalf("expected 2 tasks, got %d", len(tasks))
+	}
+	if tasks[0].Title != "persisted task" {
+		t.Errorf("got title %q, want %q", tasks[0].Title, "persisted task")
+	}
+	if tasks[1].Done != true {
+		t.Error("second task should be done")
+	}
+}
+
+func TestAutoIncrementAfterRemove(t *testing.T) {
+	s := tempStore(t)
+	s.Add("one")   // ID 1
+	s.Add("two")   // ID 2
+	s.Remove(2)    // remove highest
+	task, _ := s.Add("three") // should be ID 3, not 2
+	if task.ID != 3 {
+		t.Errorf("got ID %d after remove, want 3", task.ID)
+	}
+}
+
+func TestLoadNonExistentFile(t *testing.T) {
+	s := NewStore(filepath.Join(t.TempDir(), "nope.json"))
+	tasks, err := s.List(nil)
+	if err != nil {
+		t.Fatalf("list on missing file: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("expected 0 tasks, got %d", len(tasks))
+	}
+}
+
+func TestLoadEmptyFile(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "empty.json")
+	os.WriteFile(p, []byte{}, 0644)
+
+	s := NewStore(p)
+	tasks, err := s.List(nil)
+	if err != nil {
+		t.Fatalf("list on empty file: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("expected 0 tasks, got %d", len(tasks))
+	}
+}

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -1,0 +1,11 @@
+package task
+
+import "time"
+
+// Task represents a single tracked item.
+type Task struct {
+	ID        int       `json:"id"`
+	Title     string    `json:"title"`
+	Done      bool      `json:"done"`
+	CreatedAt time.Time `json:"created_at"`
+}


### PR DESCRIPTION
Closes #1

Spec: `.manager/specs/001-tsk-cli.md`

## Summary
- Standalone Go CLI tool that tracks tasks in `~/.tasks.json`
- Commands: `add`, `list` (with `--done`/`--pending` filters), `done`, `rm`
- JSON storage with auto-incrementing IDs
- Table-driven tests covering CRUD, round-trip, and edge cases

## Test plan
- [x] `go test ./...` passes (8 tests)