### PR TITLE
038: enhance plan command with acceptance criteria and pipeline manifest

### DIFF
--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,11 +1,12 @@
-You are acting as a PM — decomposing work into discrete, delegatable items.
+You are acting as a PM — decomposing work into discrete, delegatable items with explicit acceptance criteria, then generating a pipeline manifest for the overseer.
 
 Use context from any prior `/discuss` conversation to inform the plan. If no discussion has happened, gather enough context first by asking questions.
 
 Your job:
 1. Break the work into discrete items that can be executed independently by sub-agents
-2. For each item, write a spec file and create a GitHub issue
-3. Identify dependencies between items and suggest an execution order
+2. For each item, write a spec file with structured acceptance criteria and create a GitHub issue
+3. Identify dependencies between items and validate the dependency graph
+4. Generate a pipeline manifest file that `/run` can consume
 
 Rules:
 - NEVER write application code or modify application files
@@ -21,7 +22,21 @@ List all items with their agent role assignment:
 - **proto** — Protobuf definitions and code generation
 - **testing** — Test suites, coverage, integration tests
 
-### Step 2: Write specs
+### Step 2: Validate dependency graph
+
+Before writing specs, map out the dependency graph and validate it:
+
+1. Draw the dependency edges between items
+2. Compute the longest chain (critical path)
+3. If any chain exceeds depth 3, **stop and restructure**:
+   - Merge tightly coupled items into one
+   - Parallelize by splitting shared dependencies into smaller pieces
+   - Re-sequence to flatten the graph
+4. Report the dependency graph and critical path length to the user before proceeding
+
+**Chain depth** = number of edges on the longest path from a root (no deps) to a leaf. A chain of A -> B -> C -> D has depth 3. Anything deeper requires restructuring.
+
+### Step 3: Write specs
 For each item, create `.manager/specs/<id>-<name>.md` using this format:
 
 ```markdown
@@ -35,7 +50,22 @@ Background, related specs, dependencies.
 
 ## Requirements
 - Specific deliverables
-- Acceptance criteria
+- Implementation details
+
+## Acceptance Criteria
+Each criterion must be specific, verifiable, and self-contained. Sub-agents check these off before declaring done. The review agent verifies them against the diff.
+
+- [ ] <verb phrase describing a concrete, testable outcome>
+- [ ] <verb phrase describing a concrete, testable outcome>
+- [ ] ...
+
+### Criteria guidelines
+- Start each criterion with a verb: "Create", "Add", "Update", "Return", "Handle"
+- Be specific: "Return error when input is empty" not "Handle errors properly"
+- Be verifiable from the diff: "Add table-driven tests for Parse()" not "Has good test coverage"
+- One assertion per criterion — if it has "and", split it
+- Include both positive and negative cases where applicable
+- 5-15 criteria per spec (fewer = underspecified, more = too granular)
 
 ## Target Repo
 zarldev/<repo-name>
@@ -53,8 +83,8 @@ Any additional context from the discussion.
 
 Note: The `Target Repo` field tells `/delegate` which repo to create/clone. Use `zarldev/<name>` for all projects.
 
-### Step 3: Create GitHub issues
-Issues are created on the **target repo** using the zarldev PAT. If the repo doesn't exist yet, create the issue on `zarldev/claude-mngr` as a tracking issue.
+### Step 4: Create GitHub issues
+Issues are created on the **target repo**. If the repo doesn't exist yet, create the issue on `zarldev/claude-mngr` as a tracking issue.
 
 For each item, run:
 ```bash
@@ -71,11 +101,49 @@ gh label create testing --repo <target-repo> --color FBCA04 --description "Testi
 
 If the target repo doesn't exist yet, that's fine — `/delegate` will create it. Create the issue on `zarldev/claude-mngr` instead and note the target repo in the body.
 
-### Step 4: Output summary table
+### Step 5: Generate pipeline manifest
+
+After all specs are written and issues created, generate `.manager/pipeline.md`:
+
+```markdown
+# Pipeline: <descriptive-name>
+
+## Status: pending
+## Created: <ISO 8601 timestamp, e.g. 2026-02-18T14:30:00Z>
+
+| ID | Name | Role | Deps | Status | Attempt | Worktree |
+|----|------|------|------|--------|---------|----------|
+| <id> | <name> | <role> | <comma-separated dep IDs or —> | queued | 0/3 | — |
+```
+
+**Column definitions:**
+- **ID**: 3-digit spec ID
+- **Name**: kebab-case short name (matches spec filename)
+- **Role**: agent role (backend, frontend, proto, testing)
+- **Deps**: comma-separated IDs of specs that must be `merged` before this item can start, or `—` if none
+- **Status**: one of `queued`, `in-progress`, `in-review`, `retry`, `merged`, `blocked`
+- **Attempt**: retry counter in `current/max` format. `0/3` = not started, `1/3` = first attempt, `3/3` = final attempt
+- **Worktree**: worktree path once assigned by `/run`, or `—` if not yet started
+
+**Status lifecycle:**
+```
+queued → in-progress → in-review → merged
+                    ↘ retry (back to in-progress, increment attempt)
+                    ↘ blocked (needs human intervention)
+```
+
+The pipeline manifest is the single source of truth for `/run`. It tracks what to launch next, what's blocked, and when the pipeline is complete.
+
+### Step 6: Output summary
+
+Print the summary table:
 
 | ID | Title | Role | Depends On | Issue |
 |----|-------|------|------------|-------|
 | 001 | ... | backend | — | #1 |
 | 002 | ... | frontend | 001 | #2 |
 
-Tell the user to run `/delegate <id>` to launch a sub-agent for any item, or `/delegate all` to launch all independent items.
+Then print:
+- Dependency graph critical path length
+- Pipeline manifest path: `.manager/pipeline.md`
+- Tell the user to run `/run` to start the pipeline (NOT `/delegate`)


### PR DESCRIPTION
Closes #17

Spec: .manager/specs/038-enhanced-plan.md

Rewrites `/plan` to produce:
- Explicit acceptance criteria (checkboxes) per spec
- Dependency graph validation (max chain depth 3)
- Pipeline manifest (`.manager/pipeline.md`) for the overseer