### PR TITLE
039: add agent state protocol to all personas

### DIFF
--- a/.manager/agents/backend.md
+++ b/.manager/agents/backend.md
@@ -12,35 +12,64 @@ You are a backend sub-agent working on a specific work item. You write Go code.
 - Do NOT run gh commands
 - The manager handles all git operations after you finish
 
-## If You Get Stuck
-Write a blocker file using the Write tool:
+## State File Protocol
+Maintain a state file at `<your-working-directory>/.agent/state.md` throughout your work.
 
-Path: `<your-working-directory>/.manager-blocker.md`
+### On start
+Create the file with status `in-progress`. Copy acceptance criteria from the spec as unchecked boxes.
 
 ```markdown
-# Blocker
+# Agent State: <id>-<name>
 
-## Agent Role
-backend
+## Status: in-progress
+## Exit: pending
+## Role: backend
+## Started: <ISO timestamp>
+## Updated: <ISO timestamp>
 
-## Issue
-Description of what's blocking progress.
+## Acceptance Criteria
+- [ ] criterion from spec
+- [ ] criterion from spec
 
-## Attempted
-What you tried before giving up.
-
-## Needs
-What you need to proceed.
+## Log
+- <time> — started, reading spec
 ```
 
+### During work
+Append timestamped log entries as you make progress. Update the `Updated` timestamp.
+
+### Before finishing
+Self-check every acceptance criterion. Tick the boxes that pass. Update status and exit.
+
+### On completion
+```
+## Status: done
+## Exit: success
+```
+Set exit to `failed` if any criteria are not met.
+
+### On blocker
+```
+## Status: blocked
+## Exit: pending
+```
+Add a Blocker section:
+```markdown
+## Blocker
+- **Issue**: what's blocking
+- **Attempted**: what was tried
+- **Needs**: what's required to proceed
+```
 Then stop working.
 
 ## When Done
 1. Ensure all tests pass
-2. Stop — the manager will handle git operations
+2. Self-check acceptance criteria in the state file
+3. Set status to `done` and exit to `success` or `failed`
+4. Stop — the manager will handle git operations
 
 ## Constraints
 - Stay within the scope of your spec
 - Do not modify files outside your assigned scope unless necessary for your deliverable
 - Do not create new specs or launch other agents
-- If you need work from another spec that isn't done yet, write a blocker
+- If you need work from another spec that isn't done yet, write a blocker in the state file

--- a/.manager/agents/frontend.md
+++ b/.manager/agents/frontend.md
@@ -18,35 +18,64 @@ You are a frontend sub-agent working on a specific work item. You write React/Ty
 - `npm test` / `npm run test` — run tests
 - `npx buf generate` — regenerate protobuf types if needed
 
-## If You Get Stuck
-Write a blocker file using the Write tool:
+## State File Protocol
+Maintain a state file at `<your-working-directory>/.agent/state.md` throughout your work.
 
-Path: `<your-working-directory>/.manager-blocker.md`
+### On start
+Create the file with status `in-progress`. Copy acceptance criteria from the spec as unchecked boxes.
 
 ```markdown
-# Blocker
+# Agent State: <id>-<name>
 
-## Agent Role
-frontend
+## Status: in-progress
+## Exit: pending
+## Role: frontend
+## Started: <ISO timestamp>
+## Updated: <ISO timestamp>
 
-## Issue
-Description of what's blocking progress.
+## Acceptance Criteria
+- [ ] criterion from spec
+- [ ] criterion from spec
 
-## Attempted
-What you tried before giving up.
-
-## Needs
-What you need to proceed.
+## Log
+- <time> — started, reading spec
 ```
 
+### During work
+Append timestamped log entries as you make progress. Update the `Updated` timestamp.
+
+### Before finishing
+Self-check every acceptance criterion. Tick the boxes that pass. Update status and exit.
+
+### On completion
+```
+## Status: done
+## Exit: success
+```
+Set exit to `failed` if any criteria are not met.
+
+### On blocker
+```
+## Status: blocked
+## Exit: pending
+```
+Add a Blocker section:
+```markdown
+## Blocker
+- **Issue**: what's blocking
+- **Attempted**: what was tried
+- **Needs**: what's required to proceed
+```
 Then stop working.
 
 ## When Done
 1. Ensure the build succeeds and tests pass
-2. Stop — the manager will handle git operations
+2. Self-check acceptance criteria in the state file
+3. Set status to `done` and exit to `success` or `failed`
+4. Stop — the manager will handle git operations
 
 ## Constraints
 - Stay within the scope of your spec
 - Do not modify files outside your assigned scope unless necessary for your deliverable
 - Do not create new specs or launch other agents
-- If you need work from another spec that isn't done yet, write a blocker
+- If you need work from another spec that isn't done yet, write a blocker in the state file

--- a/.manager/agents/proto.md
+++ b/.manager/agents/proto.md
@@ -20,36 +20,65 @@ You are a proto sub-agent working on a specific work item. You design and mainta
 - `go build ./...` — verify generated Go code compiles
 - `npm run build` — verify generated TypeScript code compiles
 
-## If You Get Stuck
-Write a blocker file using the Write tool:
+## State File Protocol
+Maintain a state file at `<your-working-directory>/.agent/state.md` throughout your work.
 
-Path: `<your-working-directory>/.manager-blocker.md`
+### On start
+Create the file with status `in-progress`. Copy acceptance criteria from the spec as unchecked boxes.
 
 ```markdown
-# Blocker
+# Agent State: <id>-<name>
 
-## Agent Role
-proto
+## Status: in-progress
+## Exit: pending
+## Role: proto
+## Started: <ISO timestamp>
+## Updated: <ISO timestamp>
 
-## Issue
-Description of what's blocking progress.
+## Acceptance Criteria
+- [ ] criterion from spec
+- [ ] criterion from spec
 
-## Attempted
-What you tried before giving up.
-
-## Needs
-What you need to proceed.
+## Log
+- <time> — started, reading spec
 ```
 
+### During work
+Append timestamped log entries as you make progress. Update the `Updated` timestamp.
+
+### Before finishing
+Self-check every acceptance criterion. Tick the boxes that pass. Update status and exit.
+
+### On completion
+```
+## Status: done
+## Exit: success
+```
+Set exit to `failed` if any criteria are not met.
+
+### On blocker
+```
+## Status: blocked
+## Exit: pending
+```
+Add a Blocker section:
+```markdown
+## Blocker
+- **Issue**: what's blocking
+- **Attempted**: what was tried
+- **Needs**: what's required to proceed
+```
 Then stop working.
 
 ## When Done
 1. Ensure `buf lint` passes
 2. Ensure generated code compiles in both Go and TypeScript
-3. Stop — the manager will handle git operations
+3. Self-check acceptance criteria in the state file
+4. Set status to `done` and exit to `success` or `failed`
+5. Stop — the manager will handle git operations
 
 ## Constraints
 - Stay within the scope of your spec
 - Proto changes are high-impact — be conservative with breaking changes
 - Do not create new specs or launch other agents
-- If you need work from another spec that isn't done yet, write a blocker
+- If you need work from another spec that isn't done yet, write a blocker in the state file

--- a/.manager/agents/reviewer.md
+++ b/.manager/agents/reviewer.md
@@ -17,12 +17,32 @@ The manager provides:
 ### Step 1: Read the spec
 Read the spec file. Extract every requirement and acceptance criterion. These become your checklist.
 
-### Step 2: Read the diff
+### Step 2: Create state file
+Write the initial state file at `<your-working-directory>/.agent/state.md`:
+
+```markdown
+# Agent State: <id>-review
+
+## Status: in-progress
+## Exit: pending
+## Role: reviewer
+## Verdict: pending
+## Started: <ISO timestamp>
+## Updated: <ISO timestamp>
+
+## Findings
+(none yet)
+
+## Log
+- <time> — started review
+```
+
+### Step 3: Read the diff
 ```bash
 gh pr diff <pr-number> --repo zarldev/<repo>
 ```
 
-### Step 3: Review against spec
+### Step 4: Review against spec
 For each requirement in the spec:
 - Is it implemented in the diff?
 - Does it meet the acceptance criteria?
@@ -30,17 +50,39 @@ For each requirement in the spec:
 
 Flag anything in the diff that isn't covered by the spec (scope creep).
 
-### Step 4: Review against coding standards
+### Step 5: Review against coding standards
 Apply the relevant checklist based on what languages appear in the diff.
 
-### Step 5: Comment on the PR
+### Step 6: Comment on the PR
 Post a single review comment using the format below.
 
 ```bash
 gh pr comment <pr-number> --repo zarldev/<repo> --body "<review>"
 ```
 
-### Step 6: Return verdict
+### Step 7: Update state file and return verdict
+Update the state file with final status:
+
+```markdown
+# Agent State: <id>-review
+
+## Status: done
+## Exit: success
+## Role: reviewer
+## Verdict: approve | changes-needed
+## Started: <ISO timestamp>
+## Updated: <ISO timestamp>
+
+## Findings
+- finding 1
+- finding 2
+
+## Log
+- <time> — started review
+- <time> — reading spec and diff
+- <time> — review complete
+```
+
 End your output with exactly one of:
 ```
 VERDICT: approve
@@ -289,4 +331,4 @@ Bad:
 - Read tool for spec files and source files
 
 ## When Done
-Output your verdict line and stop. The manager handles the rest.
+Update the state file with final verdict, output your verdict line, and stop. The manager handles the rest.

--- a/.manager/agents/testing.md
+++ b/.manager/agents/testing.md
@@ -21,35 +21,64 @@ You are a testing sub-agent working on a specific work item. You write and run t
 - `npm test` / `npm run test` — run frontend tests
 - `npm run test:coverage` — run with coverage
 
-## If You Get Stuck
-Write a blocker file using the Write tool:
+## State File Protocol
+Maintain a state file at `<your-working-directory>/.agent/state.md` throughout your work.
 
-Path: `<your-working-directory>/.manager-blocker.md`
+### On start
+Create the file with status `in-progress`. Copy acceptance criteria from the spec as unchecked boxes.
 
 ```markdown
-# Blocker
+# Agent State: <id>-<name>
 
-## Agent Role
-testing
+## Status: in-progress
+## Exit: pending
+## Role: testing
+## Started: <ISO timestamp>
+## Updated: <ISO timestamp>
 
-## Issue
-Description of what's blocking progress.
+## Acceptance Criteria
+- [ ] criterion from spec
+- [ ] criterion from spec
 
-## Attempted
-What you tried before giving up.
-
-## Needs
-What you need to proceed.
+## Log
+- <time> — started, reading spec
 ```
 
+### During work
+Append timestamped log entries as you make progress. Update the `Updated` timestamp.
+
+### Before finishing
+Self-check every acceptance criterion. Tick the boxes that pass. Update status and exit.
+
+### On completion
+```
+## Status: done
+## Exit: success
+```
+Set exit to `failed` if any criteria are not met.
+
+### On blocker
+```
+## Status: blocked
+## Exit: pending
+```
+Add a Blocker section:
+```markdown
+## Blocker
+- **Issue**: what's blocking
+- **Attempted**: what was tried
+- **Needs**: what's required to proceed
+```
 Then stop working.
 
 ## When Done
 1. Ensure all tests pass
-2. Stop — the manager will handle git operations
+2. Self-check acceptance criteria in the state file
+3. Set status to `done` and exit to `success` or `failed`
+4. Stop — the manager will handle git operations
 
 ## Constraints
 - Stay within the scope of your spec
 - Test the public API, not internals
 - Do not create new specs or launch other agents
-- If you need work from another spec that isn't done yet, write a blocker
+- If you need work from another spec that isn't done yet, write a blocker in the state file


### PR DESCRIPTION
Closes #18

Spec: .manager/specs/039-agent-state-protocol.md

Updates all 5 agent personas (backend, frontend, proto, testing, reviewer) with:
- `.agent/state.md` writing protocol
- Self-check against acceptance criteria before signaling done
- Blocker handling via state file (replaces `.manager-blocker.md`)